### PR TITLE
feat: Case-insensitive biome id and renamed property 'displayName'

### DIFF
--- a/module.txt
+++ b/module.txt
@@ -1,6 +1,6 @@
 {
     "id" : "BiomesAPI",
-    "version" : "3.2.1",
+    "version" : "4.0.0",
     "isReleaseManaged" : true,
     "author" : "The Terasology Foundation",
     "displayName" : "BiomesAPI",

--- a/module.txt
+++ b/module.txt
@@ -1,11 +1,11 @@
 {
-    "id" : "BiomesAPI",
-    "version" : "4.0.0",
-    "isReleaseManaged" : true,
-    "author" : "The Terasology Foundation",
-    "displayName" : "BiomesAPI",
-    "description" : "Provides API for working with biomes, i.e., thematic sections of world.",
-    "dependencies" : [],
-    "serverSideOnly" : false,
-    "isLibrary" : true
+    "id": "BiomesAPI",
+    "version": "4.0.0",
+    "isReleaseManaged": true,
+    "author": "The Terasology Foundation",
+    "displayName": "BiomesAPI",
+    "description": "Provides API for working with biomes, i.e., thematic sections of world.",
+    "dependencies": [],
+    "serverSideOnly": false,
+    "isLibrary": true
 }

--- a/src/main/java/org/terasology/biomesAPI/Biome.java
+++ b/src/main/java/org/terasology/biomesAPI/Biome.java
@@ -15,6 +15,8 @@
  */
 package org.terasology.biomesAPI;
 
+import org.terasology.naming.Name;
+
 /**
  * Biomes can be assigned to different blocks during worldgen as well as on runtime, to provide additional metadata
  * about player's surroundings usable to enhance player experience.
@@ -29,12 +31,12 @@ public interface Biome {
      * @return An identifier that includes both the Module the biome originates from
      * and a unique biome id (unique to that module).
      */
-    String getId();
+    Name getId();
 
     /**
      * Returns human readable name of the biome.
      */
-    String getName();
+    String getDisplayName();
 
     /**
      * Biome hashCode must be deterministic, non-zero, and unique for every biome.
@@ -47,7 +49,7 @@ public interface Biome {
      */
     default short biomeHash() {
         short hash = 0;
-        char[] chars = getId().toCharArray();
+        char[] chars = getId().toLowerCase().toCharArray();
 
         for (char c : chars) {
             hash = (short) (c + 31 * hash);


### PR DESCRIPTION
I think the biome ID should be case-insensitive and thus use the `Name` class instead of a plain string. 

To clarify the difference between the ID and the _display name_ I renamed the `name` accordingly.