### PR TITLE
feat: Add Biomes Metrics Mode

### DIFF
--- a/src/main/java/org/terasology/biomesAPI/BiomeManager.java
+++ b/src/main/java/org/terasology/biomesAPI/BiomeManager.java
@@ -165,12 +165,8 @@ public class BiomeManager extends BaseComponentSystem implements BiomeRegistry {
     @ReceiveEvent(components = PlayerCharacterComponent.class)
     public void checkPlayerSpawnedEvent(OnPlayerSpawnedEvent event, EntityRef entity, LocationComponent locationComponent) {
         Vector3i spawnPos = new Vector3i(locationComponent.getWorldPosition());
-        final Optional<Biome> spawnBiomeOptional = getBiome(spawnPos);
-        if (!spawnBiomeOptional.isPresent()) {
-            return;
-        }
-        Biome spawnBiome = spawnBiomeOptional.get();
-        metricsMode.setBiome(spawnBiome.getId());
+        getBiome(spawnPos)
+            .ifPresent(spawnBiome -> metricsMode.setBiome(spawnBiome.getId()));
 
     }
 }

--- a/src/main/java/org/terasology/biomesAPI/BiomeManager.java
+++ b/src/main/java/org/terasology/biomesAPI/BiomeManager.java
@@ -163,8 +163,7 @@ public class BiomeManager extends BaseComponentSystem implements BiomeRegistry {
     }
 
     @ReceiveEvent(components = PlayerCharacterComponent.class)
-    public void checkPlayerSpawnedEvent(OnPlayerSpawnedEvent event, EntityRef entity) {
-        LocationComponent locationComponent = entity.getComponent(LocationComponent.class);
+    public void checkPlayerSpawnedEvent(OnPlayerSpawnedEvent event, EntityRef entity, LocationComponent locationComponent) {
         Vector3i spawnPos = new Vector3i(locationComponent.getWorldPosition());
         final Optional<Biome> spawnBiomeOptional = getBiome(spawnPos);
         if (!spawnBiomeOptional.isPresent()) {

--- a/src/main/java/org/terasology/biomesAPI/BiomesMetricsMode.java
+++ b/src/main/java/org/terasology/biomesAPI/BiomesMetricsMode.java
@@ -18,7 +18,8 @@ package org.terasology.biomesAPI;
 import org.terasology.rendering.nui.layers.ingame.metrics.MetricsMode;
 
 /**
- * A MetricsMode implementation to display Current Biome info in the debug section
+ * Display the name of the biome the player is currently located in in the debug overlay.
+ * <p>
  * Current biome is set when OnBiomeChanged event is triggered
  * biomeName is polled whenever MetricsMode values are updated
  */

--- a/src/main/java/org/terasology/biomesAPI/BiomesMetricsMode.java
+++ b/src/main/java/org/terasology/biomesAPI/BiomesMetricsMode.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.biomesAPI;
+
+import org.terasology.rendering.nui.layers.ingame.metrics.MetricsMode;
+
+/**
+ * A MetricsMode implementation to display Current Biome info in the debug section
+ * Current biome is set when OnBiomeChanged event is triggered
+ * biomeName is polled whenever MetricsMode values are updated
+ */
+class BiomesMetricsMode extends MetricsMode {
+
+    private String biomeName;
+
+    BiomesMetricsMode() {
+        super("\n- Biome Info -");
+    }
+
+    @Override
+    public String getMetrics() {
+        return getName()+"\n"+biomeName;
+    }
+
+    @Override
+    public boolean isAvailable() {
+        return true;
+    }
+
+    @Override
+    public boolean isPerformanceManagerMode() {
+        return false;
+    }
+
+    public void setBiome(String biomeName) {
+        this.biomeName = biomeName;
+    }
+}


### PR DESCRIPTION
### Contains

Added a new Biomes Metric mode to the debug mode showing information regarding the current biome in which the user is present. 
Also fixes the OnBiomeChanged event and block extra data storage by passing the chunk of the block as an argument to the setExtraData function. 
### How to test

Load/Create a world, Press F3 to toggle the debug mode, Press F4 to cycle between the metrics modes till the Biomes Metrics Mode is reached. This should contain the current Biome. Test by moving around with this enabled and watch the biome name change.

This was originally a part of https://github.com/MovingBlocks/Terasology/pull/3904 but after https://github.com/MovingBlocks/Terasology/pull/3942 it has been made here. 