### PR TITLE
Implement support for Conditional Biomes

### DIFF
--- a/src/main/java/org/terasology/biomesAPI/BaseConditionalBiome.java
+++ b/src/main/java/org/terasology/biomesAPI/BaseConditionalBiome.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.biomesAPI;
+
+import org.terasology.math.geom.Vector2f;
+import org.terasology.world.generation.facets.base.FieldFacet2D;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+public abstract class BaseConditionalBiome implements ConditionalBiome {
+    protected Map<Class<? extends FieldFacet2D>, Vector2f> limitedFacets = new HashMap<>();
+
+    @Override
+    public boolean isValid(Class<? extends FieldFacet2D> facetClass, Float value) {
+        Vector2f constraints = limitedFacets.get(facetClass);
+        return constraints == null || (value >= constraints.x && value <= constraints.y);
+    }
+
+    @Override
+    public Set<Class<? extends FieldFacet2D>> getLimitedFacets() {
+        return limitedFacets.keySet();
+    }
+
+    @Override
+    public void setLowerLimit(Class<? extends FieldFacet2D> facetClass, Float minimum) {
+        limitedFacets.compute(facetClass, (k, v) -> {
+            if (v == null) v = new Vector2f(minimum, Float.MAX_VALUE);
+            v.x = minimum;
+            return v;
+        });
+    }
+
+    @Override
+    public void setUpperLimit(Class<? extends FieldFacet2D> facetClass, Float maximum) {
+        limitedFacets.compute(facetClass, (k, v) -> {
+            if (v == null) v = new Vector2f(Float.MIN_VALUE, maximum);
+            v.y = maximum;
+            return v;
+        });
+    }
+}

--- a/src/main/java/org/terasology/biomesAPI/BiomeManager.java
+++ b/src/main/java/org/terasology/biomesAPI/BiomeManager.java
@@ -24,6 +24,7 @@ import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.logic.players.PlayerCharacterComponent;
+import org.terasology.math.geom.BaseVector2i;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.physics.events.MovedEvent;
@@ -34,7 +35,9 @@ import org.terasology.world.block.Block;
 import org.terasology.world.chunks.CoreChunk;
 import org.terasology.world.chunks.blockdata.ExtraDataSystem;
 import org.terasology.world.chunks.blockdata.RegisterExtraData;
+import org.terasology.world.generation.GeneratingRegion;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -95,6 +98,24 @@ public class BiomeManager extends BaseComponentSystem implements BiomeRegistry {
     @Override
     public <T extends Biome> List<T> getRegisteredBiomes(Class<T> biomeClass) {
         return biomeMap.values().stream().filter(biomeClass::isInstance).map(biomeClass::cast).collect(Collectors.toList());
+    }
+
+    @Override
+    public List<Biome> getValidBiomes(GeneratingRegion region, BaseVector2i pos) {
+        return getValidBiomes(region, pos, false);
+    }
+
+    @Override
+    public List<Biome> getValidBiomes(GeneratingRegion region, BaseVector2i pos, boolean conditionalOnly) {
+        List<Biome> matches = new ArrayList<>();
+        for (Biome biome : biomeMap.values()) {
+            if (biome instanceof ConditionalBiome) {
+                if (((ConditionalBiome) biome).isValid(region, pos)) matches.add(biome);
+            } else if (!conditionalOnly) {
+                matches.add(biome);
+            }
+        }
+        return matches;
     }
 
     /**

--- a/src/main/java/org/terasology/biomesAPI/BiomeRegistry.java
+++ b/src/main/java/org/terasology/biomesAPI/BiomeRegistry.java
@@ -16,8 +16,10 @@
 package org.terasology.biomesAPI;
 
 import org.terasology.entitySystem.systems.ComponentSystem;
+import org.terasology.math.geom.BaseVector2i;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.world.chunks.CoreChunk;
+import org.terasology.world.generation.GeneratingRegion;
 
 import java.util.Collection;
 import java.util.Optional;
@@ -96,4 +98,21 @@ public interface BiomeRegistry {
      * @return Collection of biomes of given subtype
      */
     <T extends Biome> Collection<T> getRegisteredBiomes(Class<T> biomeClass);
+
+    /**
+     * Returns all biomes that do not forbid themselves from the given location.
+     * @param region The world region
+     * @param pos The location in the world
+     * @return Collection of biomes that are valid for that location
+     */
+    Collection<Biome> getValidBiomes(GeneratingRegion region, BaseVector2i pos);
+
+    /**
+     * Returns all biomes that do not forbid themselves from the given location.
+     * @param region The world region
+     * @param pos The location in the world
+     * @param conditionalOnly If true, ignore biomes that have no restrictions
+     * @return Collection of biomes that are valid for that location
+     */
+    Collection<Biome> getValidBiomes(GeneratingRegion region, BaseVector2i pos, boolean conditionalOnly);
 }

--- a/src/main/java/org/terasology/biomesAPI/ConditionalBiome.java
+++ b/src/main/java/org/terasology/biomesAPI/ConditionalBiome.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2019 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.biomesAPI;
+
+import org.terasology.math.geom.BaseVector2i;
+import org.terasology.world.generation.GeneratingRegion;
+import org.terasology.world.generation.facets.base.FieldFacet2D;
+
+import java.util.Set;
+
+/**
+ * This interface allows biomes to accept various limits on where they may generate.
+ */
+public interface ConditionalBiome extends Biome {
+
+    /**
+     * Returns true if the biome can generate at the given value of the given facet.
+     * @param facetClass The facet to check, such as humidity or temperature.
+     * @param value This facet's value.
+     * @return True if possible.
+     */
+    default boolean isValid(Class<? extends FieldFacet2D> facetClass, Float value)
+    {
+        return true;
+    }
+
+    /**
+     * Checks whether all facets of the given location meet this biome's restrictions.
+     * @param region The game region being generated.
+     * @param pos The particular position we are checking.
+     * @return True if this biome's conditions are met.
+     */
+    default boolean isValid(GeneratingRegion region, BaseVector2i pos)
+    {
+        for (Class<? extends FieldFacet2D> classy : getLimitedFacets())
+        {
+            FieldFacet2D facetResult = region.getRegionFacet(classy);
+            if (!isValid(classy, facetResult.get(pos)))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * @return A list of all facets that this biome has restrictions towards.
+     */
+    Set<Class<? extends FieldFacet2D>> getLimitedFacets();
+
+    void setLowerLimit(Class<? extends FieldFacet2D> facetClass, Float minimum);
+
+    void setUpperLimit(Class<? extends FieldFacet2D> facetClass, Float maximum);
+
+    default void setLimits(Class<? extends FieldFacet2D> facetClass, Float minimum, Float maximum)
+    {
+        setLowerLimit(facetClass, minimum);
+        setUpperLimit(facetClass, maximum);
+    }
+
+}


### PR DESCRIPTION
This PR introduces the ability for biomes to implement arbitrary conditions that must be met for them to be selected by the world generator for a specific generating region.

These conditions are primarily intended to be world facets such as humidity, temperature, and surface elevation.

With this addition, a generator may receive a list of valid biomes to choose from for a certain area, rather than hardcoding specific conditions. This allows for modules to more easily add its own new biomes to existing world generators.