### PR TITLE
Add methods for querying block types to Biome interface

### DIFF
--- a/module.txt
+++ b/module.txt
@@ -5,7 +5,9 @@
   "author": "The Terasology Foundation",
   "displayName": "BiomesAPI",
   "description": "Provides API for working with biomes, i.e., thematic sections of world.",
-  "dependencies": [],
+  "dependencies": [
+    { "id": "CoreAssets", "minVersion": "2.2.0" }
+  ],
   "serverSideOnly": false,
   "isLibrary": true
 }

--- a/src/main/java/org/terasology/biomesAPI/Biome.java
+++ b/src/main/java/org/terasology/biomesAPI/Biome.java
@@ -15,6 +15,7 @@
  */
 package org.terasology.biomesAPI;
 
+import org.joml.Vector3ic;
 import org.terasology.engine.registry.CoreRegistry;
 import org.terasology.engine.world.block.Block;
 import org.terasology.engine.world.block.BlockManager;
@@ -42,55 +43,26 @@ public interface Biome {
     String getDisplayName();
 
     /**
-     * @return The block that should be generated as the top layer of the biome.
+     * @return The block that should be generated as the top layer of the biome at the given position.
      * Defaults to grass.
      */
-    default Block getSurfaceBlock() {
+    default Block getSurfaceBlock(Vector3ic pos, int seaLevel) {
         BlockManager blockManager = CoreRegistry.get(BlockManager.class);
         return blockManager.getBlock("CoreAssets:Grass");
     }
 
     /**
-     * @return The number of soil blocks that should appear directly below the surface block.
-     * Defaults to 32.
+     * @return The block that should be generated at the given position in the biome, which isn't the surface.
+     * Defaults to dirt for the first 32 blocks and then stone below.
      */
-    default int getSoilDepth() {
-        return 32;
-    }
-
-    /**
-     * @return The block that should be generated for getSoilDepth() blocks below the surface block.
-     * Defaults to dirt.
-     */
-    default Block getSoilBlock() {
+    default Block getBelowSurfaceBlock(Vector3ic pos, float density) {
         BlockManager blockManager = CoreRegistry.get(BlockManager.class);
-        return blockManager.getBlock("CoreAssets:Dirt");
-    }
+        if (density > 32) {
+            return blockManager.getBlock("CoreAssets:stone");
+        } else {
+            return blockManager.getBlock("CoreAssets:Dirt");
 
-    /**
-     * @return The block used to fill all space below the soil blocks.
-     * Defaults to stone.
-     */
-    default Block getSolidBlock() {
-        BlockManager blockManager = CoreRegistry.get(BlockManager.class);
-        return blockManager.getBlock("CoreAssets:stone");
-    }
-
-    /**
-     * @return Whether the surface block should be replaced with snow above getSnowHeight().
-     * Defaults to false.
-     */
-    default boolean hasHighAltitudeSnow() {
-        return false;
-    }
-
-    /**
-     * @return The minimum altitude above sea level for snow generation.
-     * If hasHighAltitudeSnow() returns true, all surface blocks more than getSnowHeight() blocks above sea level should be replaced with snow.
-     * Defaults to 96.
-     */
-    default int getSnowHeight() {
-        return 96;
+        }
     }
 
     /**

--- a/src/main/java/org/terasology/biomesAPI/Biome.java
+++ b/src/main/java/org/terasology/biomesAPI/Biome.java
@@ -15,6 +15,9 @@
  */
 package org.terasology.biomesAPI;
 
+import org.terasology.engine.registry.CoreRegistry;
+import org.terasology.engine.world.block.Block;
+import org.terasology.engine.world.block.BlockManager;
 import org.terasology.naming.Name;
 
 /**
@@ -37,6 +40,58 @@ public interface Biome {
      * Returns human readable name of the biome.
      */
     String getDisplayName();
+
+    /**
+     * @return The block that should be generated as the top layer of the biome.
+     * Defaults to grass.
+     */
+    default Block getSurfaceBlock() {
+        BlockManager blockManager = CoreRegistry.get(BlockManager.class);
+        return blockManager.getBlock("CoreAssets:Grass");
+    }
+
+    /**
+     * @return The number of soil blocks that should appear directly below the surface block.
+     * Defaults to 32.
+     */
+    default int getSoilDepth() {
+        return 32;
+    }
+
+    /**
+     * @return The block that should be generated for getSoilDepth() blocks below the surface block.
+     * Defaults to dirt.
+     */
+    default Block getSoilBlock() {
+        BlockManager blockManager = CoreRegistry.get(BlockManager.class);
+        return blockManager.getBlock("CoreAssets:Dirt");
+    }
+
+    /**
+     * @return The block used to fill all space below the soil blocks.
+     * Defaults to stone.
+     */
+    default Block getSolidBlock() {
+        BlockManager blockManager = CoreRegistry.get(BlockManager.class);
+        return blockManager.getBlock("CoreAssets:stone");
+    }
+
+    /**
+     * @return Whether the surface block should be replaced with snow above getSnowHeight().
+     * Defaults to false.
+     */
+    default boolean hasHighAltitudeSnow() {
+        return false;
+    }
+
+    /**
+     * @return The minimum altitude above sea level for snow generation.
+     * If hasHighAltitudeSnow() returns true, all surface blocks more than getSnowHeight() blocks above sea level should be replaced with snow.
+     * Defaults to 96.
+     */
+    default int getSnowHeight() {
+        return 96;
+    }
 
     /**
      * Biome hashCode must be deterministic, non-zero, and unique for every biome.


### PR DESCRIPTION
Currently, the biome API doesn't specify anything about biomes, and rasterizers have to use a switch statement over all supported biome types to generate blocks. That means biomes can't really be reused between games and rasterizers without copying a bunch of code.

This pull request adds some basic properties on biomes, which should just enough to remove hardcoded biome types in most rasterizers. For example, here's the updated portion of CoreWorlds' `SolidRasterizer`, with no reference to specific `CoreBiome`s:

```java
private Block getSurfaceBlock(Biome type, float heightAboveSea) {
    if (type.hasHighAltitudeSnow() && heightAboveSea > type.getSnowHeight()) {
        return snow;
    } else {
        return type.getSurfaceBlock();
    }
}

private Block getBelowSurfaceBlock(float density, Biome type) {
    if (density <= type.getSoilDepth()) {
        return type.getSoilBlock();
    } else {
        return type.getSolidBlock();
    }
}
```

Some of that logic could be moved to `Biome`, for example a method `Block getBelowSurfaceBlock(float density)`, but going too far in that direction could also lead to code duplication as @4Denthusiast pointed out on Discord.

This change doesn't break any existing code: biomes don't have to implement it since all the new methods have default implementations, and rasterizers can keep switching on biome types until the biomes they care about implement it. However, because methods like `getSurfaceBlock()` have default implementations, they need to get the `BlockManager` from the `CoreRegistry` and get the block from it each time they're called, which theoretically isn't good for performance, but it doesn't seem noticeable in practice. Implementers of `Biome` can get the blocks once and store them in instance variables like rasterizers do right now, so it's not a problem there.

This doesn't make biomes completely reusable, for example, plant generation and any biome-specific surface generation still need to be hardcoded in other phases. Eventually methods related to those things could be added to `Biome`, or could be kept separate.