### PR TITLE
fix: add initialize() method to Biome

### DIFF
--- a/src/main/java/org/terasology/biomesAPI/Biome.java
+++ b/src/main/java/org/terasology/biomesAPI/Biome.java
@@ -43,6 +43,11 @@ public interface Biome {
     String getDisplayName();
 
     /**
+     * Runs any necessary initialization, like caching block types, when the biome is registered.
+     */
+    default void initialize() {}
+
+    /**
      * @return The block that should be generated as the top layer of the biome at the given position.
      * Defaults to grass.
      */

--- a/src/main/java/org/terasology/biomesAPI/BiomeManager.java
+++ b/src/main/java/org/terasology/biomesAPI/BiomeManager.java
@@ -118,6 +118,7 @@ public class BiomeManager extends BaseComponentSystem implements BiomeRegistry {
     @Override
     public void registerBiome(Biome biome) {
         Preconditions.checkArgument(!biomeMap.containsKey(biome.biomeHash()), "Registering biome with same hash as one of previously registered biomes!");
+        biome.initialize();
         biomeMap.put(biome.biomeHash(), biome);
         LOGGER.info("Registered biome " + biome.getId() + " with id " + biome.biomeHash());
     }


### PR DESCRIPTION
Adds a method `initialize()`, which is called when biomes are registered. This provides a place to perform initialization, like getting blocks from the `BlockManager`, which needs to be done after systems are registered (so it doesn't happen at all in the world preview during pregeneration).