### PR TITLE
feat: restore biome-based grass and foliage tinting

### DIFF
--- a/src/main/java/org/terasology/biomesAPI/Biome.java
+++ b/src/main/java/org/terasology/biomesAPI/Biome.java
@@ -48,6 +48,20 @@ public interface Biome {
     default void initialize() {}
 
     /**
+     * @return An average humidity value for the biome, used for grass and foliage colors.
+     */
+    default float getHumidity() {
+        return 0.5f;
+    }
+
+    /**
+     * @return An average temperature value for the biome, used for grass and foliage colors.
+     */
+    default float getTemperature() {
+        return 0.5f;
+    }
+
+    /**
      * @return The block that should be generated as the top layer of the biome at the given position.
      * Defaults to grass.
      */

--- a/src/main/java/org/terasology/biomesAPI/BiomeColorProvider.java
+++ b/src/main/java/org/terasology/biomesAPI/BiomeColorProvider.java
@@ -21,8 +21,9 @@ public class BiomeColorProvider extends BaseComponentSystem implements ColorProv
 
     /* LUTs */
     private final Texture colorLut;
-
     private final Texture foliageLut;
+
+    private final Color colorCache = new Color();
 
     public BiomeColorProvider() {
         colorLut = Assets.getTexture("engine:grasscolor").get();
@@ -46,7 +47,8 @@ public class BiomeColorProvider extends BaseComponentSystem implements ColorProv
             float prod = humidity * temperature;
             return lut.getData().getPixel(
                     (int) ((1 - temperature) * 255),
-                    (int) ((1 - prod) * 255)
+                    (int) ((1 - prod) * 255),
+                    colorCache
             );
         }).orElse(Color.white);
     }

--- a/src/main/java/org/terasology/biomesAPI/BiomeColorProvider.java
+++ b/src/main/java/org/terasology/biomesAPI/BiomeColorProvider.java
@@ -1,0 +1,57 @@
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.biomesAPI;
+
+import org.terasology.engine.entitySystem.systems.BaseComponentSystem;
+import org.terasology.engine.entitySystem.systems.RegisterSystem;
+import org.terasology.engine.registry.In;
+import org.terasology.engine.registry.Share;
+import org.terasology.engine.rendering.assets.texture.Texture;
+import org.terasology.engine.utilities.Assets;
+import org.terasology.engine.world.block.ColorProvider;
+import org.terasology.nui.Color;
+import org.terasology.nui.Colorc;
+
+@Share(ColorProvider.class)
+@RegisterSystem
+public class BiomeColorProvider extends BaseComponentSystem implements ColorProvider {
+    @In
+    private BiomeRegistry biomeRegistry;
+
+    /* LUTs */
+    private Texture colorLut;
+
+    private Texture foliageLut;
+
+    public BiomeColorProvider() {
+        colorLut = Assets.getTexture("engine:grasscolor").get();
+        foliageLut = Assets.getTexture("engine:foliagecolor").get();
+    }
+
+    @Override
+    public Colorc colorLut(int x, int y, int z) {
+        return biomeRegistry.getBiome(x, y, z).map(biome -> {
+            float humidity = biome.getHumidity();
+            float temperature = biome.getTemperature();
+            float prod = humidity * temperature;
+            return colorLut.getData().getPixel(
+                    (int) ((1 - temperature) * 255),
+                    (int) ((1 - prod) * 255)
+            );
+        }).orElse(Color.white);
+    }
+
+    @Override
+    public Colorc foliageLut(int x, int y, int z) {
+        return biomeRegistry.getBiome(x, y, z).map(biome -> {
+            float humidity = biome.getHumidity();
+            float temperature = biome.getTemperature();
+            float prod = humidity * temperature;
+            return foliageLut.getData().getPixel(
+                    (int) ((1 - temperature) * 255),
+                    (int) ((1 - prod) * 255)
+            );
+        }).orElse(Color.white);
+    }
+}

--- a/src/main/java/org/terasology/biomesAPI/BiomeColorProvider.java
+++ b/src/main/java/org/terasology/biomesAPI/BiomeColorProvider.java
@@ -20,9 +20,9 @@ public class BiomeColorProvider extends BaseComponentSystem implements ColorProv
     private BiomeRegistry biomeRegistry;
 
     /* LUTs */
-    private Texture colorLut;
+    private final Texture colorLut;
 
-    private Texture foliageLut;
+    private final Texture foliageLut;
 
     public BiomeColorProvider() {
         colorLut = Assets.getTexture("engine:grasscolor").get();
@@ -31,24 +31,20 @@ public class BiomeColorProvider extends BaseComponentSystem implements ColorProv
 
     @Override
     public Colorc colorLut(int x, int y, int z) {
-        return biomeRegistry.getBiome(x, y, z).map(biome -> {
-            float humidity = biome.getHumidity();
-            float temperature = biome.getTemperature();
-            float prod = humidity * temperature;
-            return colorLut.getData().getPixel(
-                    (int) ((1 - temperature) * 255),
-                    (int) ((1 - prod) * 255)
-            );
-        }).orElse(Color.white);
+        return lookup(colorLut, x, y, z);
     }
 
     @Override
     public Colorc foliageLut(int x, int y, int z) {
+        return lookup(foliageLut, x, y, z);
+    }
+
+    private Colorc lookup(Texture lut, int x, int y, int z) {
         return biomeRegistry.getBiome(x, y, z).map(biome -> {
             float humidity = biome.getHumidity();
             float temperature = biome.getTemperature();
             float prod = humidity * temperature;
-            return foliageLut.getData().getPixel(
+            return lut.getData().getPixel(
                     (int) ((1 - temperature) * 255),
                     (int) ((1 - prod) * 255)
             );


### PR DESCRIPTION
This adds methods to `Biome` for querying the average humidity and temperature values, and a system to lookup foliage colors based on those values, for https://github.com/MovingBlocks/Terasology/pull/4828.