### PR TITLE
fix: enable block tinting in LOD chunks

### DIFF
--- a/src/main/java/org/terasology/biomesAPI/BiomeColorProvider.java
+++ b/src/main/java/org/terasology/biomesAPI/BiomeColorProvider.java
@@ -9,6 +9,7 @@ import org.terasology.engine.registry.In;
 import org.terasology.engine.registry.Share;
 import org.terasology.engine.rendering.assets.texture.Texture;
 import org.terasology.engine.utilities.Assets;
+import org.terasology.engine.world.ChunkView;
 import org.terasology.engine.world.block.ColorProvider;
 import org.terasology.nui.Color;
 import org.terasology.nui.Colorc;
@@ -31,17 +32,17 @@ public class BiomeColorProvider extends BaseComponentSystem implements ColorProv
     }
 
     @Override
-    public Colorc colorLut(int x, int y, int z) {
-        return lookup(colorLut, x, y, z);
+    public Colorc colorLut(ChunkView view, int x, int y, int z) {
+        return lookup(colorLut, view, x, y, z);
     }
 
     @Override
-    public Colorc foliageLut(int x, int y, int z) {
-        return lookup(foliageLut, x, y, z);
+    public Colorc foliageLut(ChunkView view, int x, int y, int z) {
+        return lookup(foliageLut, view, x, y, z);
     }
 
-    private Colorc lookup(Texture lut, int x, int y, int z) {
-        return biomeRegistry.getBiome(x, y, z).map(biome -> {
+    private Colorc lookup(Texture lut, ChunkView view, int x, int y, int z) {
+        return biomeRegistry.getBiome(view, x, y, z).map(biome -> {
             float humidity = biome.getHumidity();
             float temperature = biome.getTemperature();
             float prod = humidity * temperature;

--- a/src/main/java/org/terasology/biomesAPI/BiomeManager.java
+++ b/src/main/java/org/terasology/biomesAPI/BiomeManager.java
@@ -34,6 +34,7 @@ import org.terasology.engine.registry.In;
 import org.terasology.engine.registry.Share;
 import org.terasology.engine.rendering.nui.NUIManager;
 import org.terasology.engine.rendering.nui.layers.ingame.metrics.DebugMetricsSystem;
+import org.terasology.engine.world.ChunkView;
 import org.terasology.engine.world.WorldProvider;
 import org.terasology.engine.world.block.Block;
 import org.terasology.engine.world.chunks.Chunk;
@@ -76,6 +77,17 @@ public class BiomeManager extends BaseComponentSystem implements BiomeRegistry {
     @Override
     public Optional<Biome> getBiome(int x, int y, int z) {
         final short biomeHash = (short) worldProvider.getExtraData("BiomesAPI.biomeHash", x, y, z);
+        if (biomeHash == 0) {
+            return Optional.empty();
+        }
+        Preconditions.checkArgument(biomeMap.containsKey(biomeHash), "Trying to use non-registered biome!");
+        return Optional.of(biomeMap.get(biomeHash));
+    }
+
+    @Override
+    public Optional<Biome> getBiome(ChunkView view, int relX, int relY, int relZ) {
+        biomeHashIndex = blockDataManager.getSlotNumber("BiomesAPI.biomeHash");
+        final short biomeHash = (short) view.getExtraData(biomeHashIndex, relX, relY, relZ);
         if (biomeHash == 0) {
             return Optional.empty();
         }

--- a/src/main/java/org/terasology/biomesAPI/BiomeRegistry.java
+++ b/src/main/java/org/terasology/biomesAPI/BiomeRegistry.java
@@ -4,6 +4,7 @@ package org.terasology.biomesAPI;
 
 import org.joml.Vector3ic;
 import org.terasology.engine.entitySystem.systems.ComponentSystem;
+import org.terasology.engine.world.ChunkView;
 import org.terasology.engine.world.chunks.Chunk;
 
 import java.util.Collection;
@@ -81,6 +82,16 @@ public interface BiomeRegistry {
      * @return Biome of the block
      */
     Optional<Biome> getBiome(int x, int y, int z);
+
+    /**
+     * Gets biome at position in chunk view.
+     *
+     * @param relX x position of the block to get biome of, relative to the chunk view
+     * @param relY y position of the block to get biome of, relative to the chunk view
+     * @param relZ z position of the block to get biome of, relative to the chunk view
+     * @return Biome of the block
+     */
+    Optional<Biome> getBiome(ChunkView view, int relX, int relY, int relZ);
 
     /**
      * Returns all registered biomes of specified subtype.


### PR DESCRIPTION
Updates for the API changes in https://github.com/MovingBlocks/Terasology/pull/4847, querying biomes from the `ChunkView` used for meshing instead of the `WorldProvider`.