### PR TITLE
qa: checkstyle, spotbugs

### DIFF
--- a/src/main/java/org/terasology/biomesAPI/Biome.java
+++ b/src/main/java/org/terasology/biomesAPI/Biome.java
@@ -1,18 +1,6 @@
-/*
- * Copyright 2018 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2018 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
 package org.terasology.biomesAPI;
 
 import org.joml.Vector3ic;
@@ -22,8 +10,8 @@ import org.terasology.engine.world.block.BlockManager;
 import org.terasology.gestalt.naming.Name;
 
 /**
- * Biomes can be assigned to different blocks during worldgen as well as on runtime, to provide additional metadata
- * about player's surroundings usable to enhance player experience.
+ * Biomes can be assigned to different blocks during worldgen as well as on runtime, to provide additional metadata about player's
+ * surroundings usable to enhance player experience.
  * <p>
  * Biomes are easiest implemented in enums, and are meant to be implemented like that.
  *
@@ -32,8 +20,7 @@ import org.terasology.gestalt.naming.Name;
 public interface Biome {
 
     /**
-     * @return An identifier that includes both the Module the biome originates from
-     * and a unique biome id (unique to that module).
+     * @return An identifier that includes both the Module the biome originates from and a unique biome id (unique to that module).
      */
     Name getId();
 
@@ -45,7 +32,8 @@ public interface Biome {
     /**
      * Runs any necessary initialization, like caching block types, when the biome is registered.
      */
-    default void initialize() {}
+    default void initialize() {
+    }
 
     /**
      * @return An average humidity value for the biome, used for grass and foliage colors.
@@ -62,8 +50,7 @@ public interface Biome {
     }
 
     /**
-     * @return The block that should be generated as the top layer of the biome at the given position.
-     * Defaults to grass.
+     * @return The block that should be generated as the top layer of the biome at the given position. Defaults to grass.
      */
     default Block getSurfaceBlock(Vector3ic pos, int seaLevel) {
         BlockManager blockManager = CoreRegistry.get(BlockManager.class);
@@ -71,8 +58,8 @@ public interface Biome {
     }
 
     /**
-     * @return The block that should be generated at the given position in the biome, which isn't the surface.
-     * Defaults to dirt for the first 32 blocks and then stone below.
+     * @return The block that should be generated at the given position in the biome, which isn't the surface. Defaults to dirt for the
+     *         first 32 blocks and then stone below.
      */
     default Block getBelowSurfaceBlock(Vector3ic pos, float density) {
         BlockManager blockManager = CoreRegistry.get(BlockManager.class);
@@ -87,9 +74,9 @@ public interface Biome {
     /**
      * Biome hashCode must be deterministic, non-zero, and unique for every biome.
      * <p>
-     * Please consider overriding this method to return constant values, hard-coded for each of the biomes.
-     * No assumptions should however be made from any external module using biomes about their constant value,
-     * i.e. modules should always retrieve biome hash using this function, and not hard-code any constant values.
+     * Please consider overriding this method to return constant values, hard-coded for each of the biomes. No assumptions should however be
+     * made from any external module using biomes about their constant value, i.e. modules should always retrieve biome hash using this
+     * function, and not hard-code any constant values.
      *
      * @return Hashcode of the biome
      */

--- a/src/main/java/org/terasology/biomesAPI/BiomeManager.java
+++ b/src/main/java/org/terasology/biomesAPI/BiomeManager.java
@@ -1,18 +1,6 @@
-/*
- * Copyright 2018 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2018 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
 package org.terasology.biomesAPI;
 
 import com.google.common.base.Preconditions;
@@ -53,7 +41,7 @@ import java.util.stream.Collectors;
 @ExtraDataSystem
 public class BiomeManager extends BaseComponentSystem implements BiomeRegistry {
 
-    private static final Logger logger = LoggerFactory.getLogger(BiomeManager.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(BiomeManager.class);
 
     @In
     protected EntityManager entityManager;
@@ -67,8 +55,6 @@ public class BiomeManager extends BaseComponentSystem implements BiomeRegistry {
     protected ExtraBlockDataManager blockDataManager;
 
     private final Map<Short, Biome> biomeMap = new HashMap<>();
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(BiomeManager.class);
 
     private BiomesMetricsMode metricsMode;
 
@@ -129,10 +115,11 @@ public class BiomeManager extends BaseComponentSystem implements BiomeRegistry {
 
     @Override
     public void registerBiome(Biome biome) {
-        Preconditions.checkArgument(!biomeMap.containsKey(biome.biomeHash()), "Registering biome with same hash as one of previously registered biomes!");
+        Preconditions.checkArgument(!biomeMap.containsKey(biome.biomeHash()),
+                "Registering biome with same hash as one of previously registered biomes!");
         biome.initialize();
         biomeMap.put(biome.biomeHash(), biome);
-        LOGGER.info("Registered biome " + biome.getId() + " with id " + biome.biomeHash());
+        LOGGER.info("Registered biome {} with id {}", biome.getId(), biome.biomeHash());
     }
 
     /**
@@ -152,7 +139,7 @@ public class BiomeManager extends BaseComponentSystem implements BiomeRegistry {
                 // fully loaded.
                 // Leaving a WARN message here to see whether this can occur under other circumstances. Eventually, we
                 // may reduce the logging level further, probably to DEBUG.
-                logger.warn("Missing biome information for {}", !oldBiomeOptional.isPresent() ? oldPosition : newPosition);
+                LOGGER.warn("Missing biome information for {}", !oldBiomeOptional.isPresent() ? oldPosition : newPosition);
                 return;
             }
             if (!oldBiomeOptional.isPresent()) {

--- a/src/main/java/org/terasology/biomesAPI/BiomesMetricsMode.java
+++ b/src/main/java/org/terasology/biomesAPI/BiomesMetricsMode.java
@@ -1,18 +1,6 @@
-/*
- * Copyright 2020 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2020 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
 package org.terasology.biomesAPI;
 
 import org.terasology.engine.rendering.nui.layers.ingame.metrics.MetricsMode;
@@ -20,8 +8,7 @@ import org.terasology.engine.rendering.nui.layers.ingame.metrics.MetricsMode;
 /**
  * Display the name of the biome the player is currently located in in the debug overlay.
  * <p>
- * Current biome is set when OnBiomeChanged event is triggered
- * biomeName is polled whenever MetricsMode values are updated
+ * Current biome is set when OnBiomeChanged event is triggered biomeName is polled whenever MetricsMode values are updated
  */
 class BiomesMetricsMode extends MetricsMode {
 
@@ -33,7 +20,7 @@ class BiomesMetricsMode extends MetricsMode {
 
     @Override
     public String getMetrics() {
-        return getName()+"\n"+biomeName;
+        return getName() + "\n" + biomeName;
     }
 
     @Override

--- a/src/main/java/org/terasology/biomesAPI/OnBiomeChangedEvent.java
+++ b/src/main/java/org/terasology/biomesAPI/OnBiomeChangedEvent.java
@@ -1,18 +1,6 @@
-/*
- * Copyright 2018 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2018 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
 package org.terasology.biomesAPI;
 
 import org.terasology.gestalt.entitysystem.event.Event;


### PR DESCRIPTION
* use standard comments
* shorten line lenght
* logger was defined twice
* use {} for logger parameters
* whitespaces so no warning is produced